### PR TITLE
Migrate formatting_html.py into xarray core

### DIFF
--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -20,10 +20,6 @@ STATIC_FILES = (
     ("xarray.static.css", "style.css"),
 )
 
-from xarray.core.options import OPTIONS
-
-OPTIONS["display_expand_groups"] = "default"
-
 
 @lru_cache(None)
 def _load_static_files():


### PR DESCRIPTION
Draft:

This PR migrates the `formatting_html.py` module to `xarray/core/formatting_html.py` as part of the on-going effort to merge `xarray-datatree` into `xarray`.

One thing of note is that the importing and setting the `OPTIONS` to `"default"` in `datatree/formatting_html.py` ([lines](https://github.com/xarray-contrib/datatree/blob/main/datatree/formatting_html.py#L13%23L15)) were moved into `xarray/core/options.py` on [#L23](https://github.com/pydata/xarray/blob/main/xarray/core/options.py#L23) and [#L49](https://github.com/pydata/xarray/blob/main/xarray/core/options.py#L49). So, I did not add them back to `xarray/core/formatting_html.py`. 

* [x] Completes migration step for `datatree/formating_htmls.py` https://github.com/pydata/xarray/issues/8572
* [x] Tests added
* [ ] ~~User visible changes (including notable bug fixes) are documented in whats-new.rst~~
* [ ] ~~New functions/methods are listed in api.rst~~